### PR TITLE
Bugfix/require message type

### DIFF
--- a/lerna.json
+++ b/lerna.json
@@ -1,5 +1,5 @@
 {
   "$schema": "node_modules/lerna/schemas/lerna-schema.json",
   "useWorkspaces": true,
-  "version": "0.5.1"
+  "version": "0.5.2"
 }

--- a/packages/nlon/lib/client.mjs
+++ b/packages/nlon/lib/client.mjs
@@ -2,7 +2,7 @@ import stream from 'stream'
 import ndjson from 'ndjson'
 import pino from 'pino'
 import { nanoid } from 'nanoid'
-import { Message } from './protocol.mjs'
+import { Message, MessageTypes } from './protocol.mjs'
 import { ClientDisconnectedError, InvalidMessageError, StreamingError } from './error.mjs'
 import { StreamContext } from './stream.context.mjs'
 import { Correspondence } from './correspondence/correspondence.mjs'
@@ -117,6 +117,7 @@ export class Client extends stream.EventEmitter {
   */
   send (message) {
     this.#requireConnected('Can\'t send on already disconnected client!')
+    message.type ??= MessageTypes.Data
     Message.validate(message)
 
     this.#logger.debug({ message }, 'Sending message')

--- a/packages/nlon/lib/protocol.mjs
+++ b/packages/nlon/lib/protocol.mjs
@@ -182,5 +182,8 @@ export class Message {
     assert(message?.header?.correspondenceId?.length > 0,
       'Missing correspondence id!')
     assert(message?.header?.subject?.length > 0, 'Missing subject!')
+    assert(message?.type, 'Missing message type!')
+    assert(Object.values(MessageTypes).includes(message?.type),
+      `Unknown message type: ${message?.type}`)
   }
 }

--- a/packages/nlon/package.json
+++ b/packages/nlon/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@elementbound/nlon",
-  "version": "0.5.1",
+  "version": "0.5.2",
   "description": "",
   "main": "index.js",
   "scripts": {

--- a/packages/nlon/test/client.test.mjs
+++ b/packages/nlon/test/client.test.mjs
@@ -36,6 +36,7 @@ describe('Client', () => {
     // Given
     const message = new Message({
       header: new MessageHeader({ subject: 'test' }),
+      type: MessageTypes.Data,
       body: 'ping'
     })
 
@@ -66,7 +67,8 @@ describe('Client', () => {
   it('should throw on send after disconnect', () => {
     // Given
     const message = new Message({
-      header: new MessageHeader({ subject: 'test' })
+      header: new MessageHeader({ subject: 'test' }),
+      type: MessageTypes.Data
     })
     client.disconnect()
 
@@ -78,6 +80,7 @@ describe('Client', () => {
     // Given
     const expected = new Message({
       header: new MessageHeader({ subject: 'test' }),
+      type: MessageTypes.Data,
       body: 'ping'
     })
 
@@ -104,6 +107,7 @@ describe('Client', () => {
     // Given
     const message = new Message({
       header: new MessageHeader({ subject: 'test' }),
+      type: MessageTypes.Data,
       body: 'ping'
     })
 

--- a/packages/nlon/test/protocol.test.mjs
+++ b/packages/nlon/test/protocol.test.mjs
@@ -1,12 +1,17 @@
 import { describe, it } from 'node:test'
 import assert from 'node:assert'
-import { Message, MessageHeader } from '../lib/protocol.mjs'
+import { Message, MessageHeader, MessageTypes } from '../lib/protocol.mjs'
 
 const invalidMessages = [
   [{}, 'missing header'],
   [{ header: {} }, 'empty header'],
   [{ header: { correspondenceId: '' } }, 'empty correspondenceId'],
-  [{ header: { correspondenceId: 'test', subject: '' } }, 'empty subject']
+  [{ header: { correspondenceId: 'test', subject: '' } }, 'empty subject'],
+  [{ header: { correspondenceId: 'test', subject: 'test' } }, 'missing type'],
+  [
+    { header: { correspondenceId: 'test', subject: 'test' }, type: 'foo' },
+    'invalid type'
+  ]
 ]
 
 const validMessages = [
@@ -15,7 +20,8 @@ const validMessages = [
       header: new MessageHeader({
         correspondenceId: 'test',
         subject: 'test'
-      })
+      }),
+      type: MessageTypes.Data
     }),
     'without body and authorization'
   ],
@@ -26,7 +32,8 @@ const validMessages = [
         correspondenceId: 'test',
         subject: 'test',
         authorization: 'super-secret'
-      })
+      }),
+      type: MessageTypes.Data
     }),
     'without body'
   ],
@@ -38,7 +45,7 @@ const validMessages = [
         subject: 'test',
         authorization: 'super-secret'
       }),
-
+      type: MessageTypes.Data,
       body: 'Hello world!'
     }),
     'with body'

--- a/packages/nlon/test/server.test.mjs
+++ b/packages/nlon/test/server.test.mjs
@@ -30,7 +30,8 @@ describe('Server', () => {
     await send(stream, new Message({
       header: new MessageHeader({
         subject: 'test'
-      })
+      }),
+      type: MessageTypes.Data
     }))
 
     // Then
@@ -49,7 +50,8 @@ describe('Server', () => {
     await send(stream, new Message({
       header: new MessageHeader({
         subject: 'test-unfinished'
-      })
+      }),
+      type: MessageTypes.Data
     }))
 
     // Then
@@ -65,7 +67,8 @@ describe('Server', () => {
     await send(stream, new Message({
       header: new MessageHeader({
         subject: 'unknown'
-      })
+      }),
+      type: MessageTypes.Data
     }))
 
     // Then
@@ -90,7 +93,8 @@ describe('Server', () => {
     await send(stream, new Message({
       header: new MessageHeader({
         subject: 'test-exception'
-      })
+      }),
+      type: MessageTypes.Data
     }))
 
     // Then
@@ -118,7 +122,8 @@ describe('Server', () => {
     await send(stream, new Message({
       header: new MessageHeader({
         subject: 'test-exception'
-      })
+      }),
+      type: MessageTypes.Data
     }))
     await sleep(delay + 10)
 
@@ -143,7 +148,8 @@ describe('Server', () => {
     await send(stream, new Message({
       header: new MessageHeader({
         subject: 'test-exception'
-      })
+      }),
+      type: MessageTypes.Data
     }))
 
     // Then
@@ -168,7 +174,8 @@ describe('Server', () => {
     await send(stream, new Message({
       header: new MessageHeader({
         subject: 'test-exception'
-      })
+      }),
+      type: MessageTypes.Data
     }))
 
     // Then
@@ -198,7 +205,8 @@ describe('Server', () => {
 
     // When
     await send(stream, new Message({
-      header
+      header,
+      type: MessageTypes.Data
     }))
 
     // Then


### PR DESCRIPTION
Require message type to be present - missing this meant that correspondences can receive messages and don't do anything, as there is no message type to decide on appropriate action.